### PR TITLE
`Disable_REST_API::get_current_route()`: Check `rest_route` query var existence before access

### DIFF
--- a/classes/disable-rest-api.php
+++ b/classes/disable-rest-api.php
@@ -72,7 +72,9 @@ class Disable_REST_API {
 	 * @return string
 	 */
 	private function get_current_route() {
-		$rest_route = $GLOBALS['wp']->query_vars['rest_route'];
+		$rest_route = isset($GLOBALS['wp']->query_vars['rest_route']) ?
+			$GLOBALS['wp']->query_vars['rest_route'] :
+			'';
 
 		return ( empty( $rest_route ) || '/' == $rest_route ) ?
 			$rest_route :


### PR DESCRIPTION
Fix https://wordpress.org/support/topic/php-error-notice-trying-to-access-array-offset-on-value-of-type-null/

Not using null coalescing operator (`??`) because of [PHP 5.6 support](https://github.com/dmchale/disable-json-api/blob/50d00ad44ef6f1e049dc07105679170cee03cdac/readme.txt#L5).