### PR TITLE
Update plugin compatibility for WordPress 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ routes as desired. Manage route access for logged-in users based on their User R
  5. In version 1.6 we added support for per-role rules and did a number of other housekeeping updates in the code.
  6. In version 1.7 we changed how we cache-bust static file enqueues, and repaired a logic bug in the role-based default_allow checks.
  7. In version 1.8 we provided a new filter so devs can customize the error message sent back if you fail the authentication check; updated minimum requirements to PHP 5.6 (up from 5.3) and WordPress 4.9 (up from WP 4.4); patched a Fatal Error when activating plugin on installations running LearnDash.
+ 8. In version 1.9.0 we tested against WordPress 7.0.2, hardened option defaults, improved REST route detection, and tightened admin input/output handling.
 ## Credits
 Authored by Dave McHale. Contributed to by Tang Rufus.
 ## License

--- a/admin.php
+++ b/admin.php
@@ -13,7 +13,10 @@
         <?php esc_html_e( "Rules for", "disable-json-api" ); ?>: <select name="role" id="dra-role">
             <option value="none"><?php esc_html_e( "Unauthenticated Users", "disable-json-api" ); ?></option>
 			<?php
-			$role = ( isset( $_GET['role'] ) ) ? $_GET['role'] : 'none';
+			$role = ( isset( $_GET['role'] ) ) ? sanitize_key( wp_unslash( $_GET['role'] ) ) : 'none';
+			if ( ! DRA_Helpers::is_valid_role( $role ) ) {
+				$role = 'none';
+			}
 			wp_dropdown_roles( $role );
 			?>
         </select>

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -18,6 +18,8 @@ class DRA_Admin {
 		foreach ( $all_routes as $route ) {
 			$is_route_namespace = in_array( ltrim( $route, "/" ), $all_namespaces );
 			$checkedProp        = self::get_route_checked_prop( $route, $allowed_routes );
+			$route_attr         = esc_attr( $route );
+			$route_js           = esc_js( $route );
 
 			if ( $is_route_namespace || "/" == $route ) {
 				$current_namespace = $route;
@@ -26,14 +28,14 @@ class DRA_Admin {
 				}
 
 				$route_for_display = ( "/" == $route ) ? "/ <em>" . esc_html__( "REST API ROOT", "disable-json-api" ) . "</em>" : esc_html( $route );
-				echo "<label class='switch'><input name='rest_routes[]' value='$route' type='checkbox' id='dra_namespace_$loopCounter' onclick='dra_namespace_click(\"$route\", $loopCounter)' $checkedProp><span class='slider'></span></label><h2><label for='dra_namespace_$loopCounter'>&nbsp;$route_for_display</label></h2><ul>";
+				echo "<label class='switch'><input name='rest_routes[]' value='$route_attr' type='checkbox' id='dra_namespace_$loopCounter' onclick='dra_namespace_click(\"$route_js\", $loopCounter)' $checkedProp><span class='slider'></span></label><h2><label for='dra_namespace_$loopCounter'>&nbsp;$route_for_display</label></h2><ul>";
 
 				if ( "/" == $route ) {
-					echo "<li>" . sprintf( esc_html__( "On this website, the REST API root is %s", "disable-json-api" ), "<strong>" . rest_url() . "</strong>" ) . "</li>";
+					echo "<li>" . sprintf( esc_html__( "On this website, the REST API root is %s", "disable-json-api" ), "<strong>" . esc_url( rest_url() ) . "</strong>" ) . "</li>";
 				}
 
 			} else {
-				echo "<li><label class='switch'><input name='rest_routes[]' id='dra_namespace_$loopCounter' value='$route' type='checkbox' data-namespace='$current_namespace' $checkedProp><span class='slider'></span></label><label for='dra_namespace_$loopCounter'>&nbsp;" . esc_html( $route ) . "</label></li>";
+				echo "<li><label class='switch'><input name='rest_routes[]' id='dra_namespace_$loopCounter' value='$route_attr' type='checkbox' data-namespace='" . esc_attr( $current_namespace ) . "' $checkedProp><span class='slider'></span></label><label for='dra_namespace_$loopCounter'>&nbsp;" . esc_html( $route ) . "</label></li>";
 			}
 
 			$loopCounter ++;
@@ -67,7 +69,7 @@ class DRA_Admin {
 		$default_allow_true_checked  = '';
 		$default_allow_false_checked = '';
 
-		$role_default_allow = DRA_Helpers::get_default_allow_for_role( $role );
+		$role_default_allow = call_user_func( array( 'DRA_Helpers', 'get_default_allow_for_role' ), $role );
 		if ( $role_default_allow ) {
 			$default_allow_true_checked = ' checked="checked"';
 		} else {
@@ -75,7 +77,7 @@ class DRA_Admin {
 		}
 
 		/* translators: name of user role */
-		echo sprintf( '<h2>%s</h2>', sprintf( esc_html__( 'Manage Rules for %s Users', 'disable-json-api' ), DRA_Helpers::get_role_name( $role ) ) );
+		echo sprintf( '<h2>%s</h2>', sprintf( esc_html__( 'Manage Rules for %s Users', 'disable-json-api' ), esc_html( call_user_func( array( 'DRA_Helpers', 'get_role_name' ), $role ) ) ) );
 		?>
         <p style="font-style:italic;">
 			<?php

--- a/classes/disable-rest-api.php
+++ b/classes/disable-rest-api.php
@@ -76,6 +76,10 @@ class Disable_REST_API {
 			$GLOBALS['wp']->query_vars['rest_route'] :
 			'';
 
+		if ( '' === $rest_route && isset( $_GET['rest_route'] ) ) {
+			$rest_route = wp_unslash( $_GET['rest_route'] );
+		}
+
 		return ( empty( $rest_route ) || '/' == $rest_route ) ?
 			$rest_route :
 			untrailingslashit( $rest_route );
@@ -91,7 +95,7 @@ class Disable_REST_API {
 	 */
 	private function is_route_allowed( $currentRoute ) {
 
-		$current_options    = get_option( 'disable_rest_api_options', array() );
+		$current_options    = $this->get_options();
 		$current_user_roles = $this->get_current_user_roles();
 
 		// Loop through user roles belonging to the current user
@@ -99,9 +103,16 @@ class Disable_REST_API {
 
 			// If we have a definition for the current user's role
 			if ( isset( $current_options['roles'][ $role ] ) ) {
+				$role_options = wp_parse_args(
+					$current_options['roles'][ $role ],
+					array(
+						'default_allow' => 'none' === $role ? false : true,
+						'allow_list'    => array(),
+					)
+				);
 
 				// If any role for this user is set to Allow Full REST API Access, return true automatically
-				if ( true === $current_options['roles'][ $role ]['default_allow'] ) {
+				if ( true === (bool) $role_options['default_allow'] ) {
 					return true;
 				}
 
@@ -129,8 +140,31 @@ class Disable_REST_API {
 		// Most likely, we're here because the request is from a user role we don't have a definition for.
 		// Return the plugin-global setting for what should be done in the case of something we don't know what to do with.
 		// As of this writing in v1.6, this is "allow" by default since we want new User Roles to be ALLOWED access to everything until an admin chooses to take that right away.
-		return $current_options['default_allow'];
+		return (bool) $current_options['default_allow'];
 
+	}
+
+
+	/**
+	 * Get plugin options with a known shape.
+	 *
+	 * @return array
+	 */
+	private function get_options() {
+		$current_options = get_option( 'disable_rest_api_options', array() );
+
+		if ( ! is_array( $current_options ) ) {
+			$current_options = array();
+		}
+
+		return wp_parse_args(
+			$current_options,
+			array(
+				'version'       => DISABLE_REST_API_PLUGIN_VER,
+				'default_allow' => true,
+				'roles'         => array(),
+			)
+		);
 	}
 
 
@@ -164,7 +198,7 @@ class Disable_REST_API {
 	public function settings_link( $links ) {
 
 		$settings_url  = menu_page_url( self::MENU_SLUG, false );
-		$settings_link = "<a href='$settings_url'>" . esc_html__( "Settings", "disable-json-api" ) . "</a>";
+		$settings_link = '<a href="' . esc_url( $settings_url ) . '">' . esc_html__( "Settings", "disable-json-api" ) . '</a>';
 		array_unshift( $links, $settings_link );
 
 		return $links;
@@ -213,7 +247,7 @@ class Disable_REST_API {
 		}
 
 		// Confirm a valid role has been passed
-		$role = ( isset( $_POST['role'] ) ) ? $_POST['role'] : 'dra-undefined';
+		$role = ( isset( $_POST['role'] ) ) ? sanitize_key( wp_unslash( $_POST['role'] ) ) : 'dra-undefined';
 		if ( ! DRA_Helpers::is_valid_role( $role ) ) {
 			add_settings_error( 'DRA-notices', esc_attr( 'settings_updated' ), esc_html__( 'Invalid user role detected when processing form. No updates have been made.', 'disable-json-api' ), 'error' );
 
@@ -224,10 +258,10 @@ class Disable_REST_API {
 		$default_allow = ( isset( $_POST['default_allow'] ) && "1" == $_POST['default_allow'] ) ? true : false;
 
 		// Catch the routes that should be allowed
-		$rest_routes = ( isset( $_POST['rest_routes'] ) ) ? wp_unslash( $_POST['rest_routes'] ) : array();
+		$rest_routes = ( isset( $_POST['rest_routes'] ) && is_array( $_POST['rest_routes'] ) ) ? array_map( 'strval', wp_unslash( $_POST['rest_routes'] ) ) : array();
 
 		// Retrieve all current rules for all roles
-		$arr_option = get_option( 'disable_rest_api_options' );
+		$arr_option = $this->get_options();
 
 		// If resetting or allowlist is empty, clear the option and exit the function
 		if ( empty( $rest_routes ) || isset( $_POST['reset'] ) ) {
@@ -277,7 +311,7 @@ class Disable_REST_API {
 	 */
 	private function get_wp_error( $access ) {
 		$dra_error_message = apply_filters( 'dra_error_message', 'DRA: Only authenticated users can access the REST API.', $access );
-		$error_message     = esc_html__( $dra_error_message, 'disable-json-api' );
+		$error_message     = esc_html( $dra_error_message );
 
 		if ( is_wp_error( $access ) ) {
 			$access->add( 'rest_cannot_access', $error_message, array( 'status' => rest_authorization_required_code() ) );

--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -44,7 +44,7 @@ class DRA_Helpers {
 		// Loop through ALL routes, find out if any exist in the previously-existing rules. If so, they SHOULD be allowed. Default for everyone is false
 		foreach ( $all_routes as $route ) {
 			$new_value = false;
-			if ( ! empty( $allowed_routes ) && in_array( $route, $allowed_routes ) ) {
+			if ( ! empty( $allowed_routes ) && in_array( $route, $allowed_routes, true ) ) {
 				$new_value = true;
 			}
 			$new_rules[ esc_html( $route ) ] = $new_value;

--- a/disable-json-api.php
+++ b/disable-json-api.php
@@ -3,9 +3,10 @@
  * Plugin Name: Disable REST API
  * Plugin URI: http://www.binarytemplar.com/disable-json-api
  * Description: Disable the use of the REST API on your website to anonymous users. You can optionally enable select endpoints if you wish. Now with support for User Roles!
- * Version: 1.9-alpha
+ * Version: 1.9.0
  * Requires at least: 4.9
  * Requires PHP: 5.6
+ * Tested up to: 7.0.2
  * Author: Dave McHale
  * Author URI: http://www.binarytemplar.com
  * License: GPL2+
@@ -14,7 +15,7 @@
  * Domain Path: /languages
  */
 
-const DISABLE_REST_API_PLUGIN_VER = '1.9-alpha';
+const DISABLE_REST_API_PLUGIN_VER = '1.9.0';
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {

--- a/js/admin-footer.js
+++ b/js/admin-footer.js
@@ -1,13 +1,13 @@
 function dra_set_route_display( new_display ) {
-    document.querySelectorAll('div#route-container, input#dra-reset-button').forEach( el => {
-        el.addEventListener( 'click', () => {
-            el.style.display = new_display;
-        });
+    document.querySelectorAll('div#route-container, input#dra-reset-button').forEach((el) => {
+        el.style.display = new_display;
     });
 }
 
 function dra_maybe_show_routes() {
-    let manage = document.querySelector('input[name=default_allow]:checked').value.toString();
+    const selected = document.querySelector('input[name=default_allow]:checked');
+    let manage = selected ? selected.value.toString() : '0';
+
     if ( '0' === manage ) {
         dra_set_route_display( 'block' );
     } else {
@@ -23,7 +23,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
         window.location.href = window.location.origin + window.location.pathname + '?page=disable_rest_api_settings&role=' + this.value;
     });
 
-    document.querySelectorAll('input[name=default_allow]').forEach( el => {
+    document.querySelectorAll('input[name=default_allow]').forEach((el) => {
         el.addEventListener( 'change', () => {
             dra_maybe_show_routes();
         });

--- a/js/admin-header.js
+++ b/js/admin-header.js
@@ -1,7 +1,20 @@
 function dra_namespace_click(namespace, id) {
-    if (document.getElementById('#dra_namespace_' + id).checked) {
-        document.getElementById("#route-container input[data-namespace='" + namespace + "']").checked = true;
+    const namespaceInput = document.getElementById('dra_namespace_' + id);
+    if (!namespaceInput) {
+        return;
+    }
+
+    const routeInputs = Array.from(document.querySelectorAll('#route-container input[data-namespace]')).filter((routeInput) => {
+        return routeInput.dataset.namespace === namespace;
+    });
+
+    if (namespaceInput.checked) {
+        routeInputs.forEach((routeInput) => {
+            routeInput.checked = true;
+        });
     } else {
-        document.getElementById("#route-container input[data-namespace='" + namespace + "']").checked = false;
+        routeInputs.forEach((routeInput) => {
+            routeInput.checked = false;
+        });
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: dmchale, tangrufus
 Tags: admin, api, json, REST, rest-api, disable
 Requires at least: 4.9
 Requires PHP: 5.6
-Tested up to: 6.3
-Stable tag: 1.8
+Tested up to: 7.0.2
+Stable tag: 1.9.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,6 +45,12 @@ This plugin is ONLY meant to disable endpoints accessible via the core REST API 
 3. The Settings page lets you selectively whitelist endpoints registered with the REST API, on a per-user-role basis.
 
 == Changelog ==
+
+= 1.9.0 =
+* Tested up to WP v7.0.2
+* Hardened settings defaults for fresh installs and upgraded option data.
+* Improved route detection for modern REST requests.
+* Sanitized settings role/route input and escaped admin settings output.
 
 = 1.8 =
 * Tested up to WP v6.3


### PR DESCRIPTION
## Summary
- Bump plugin/readme metadata to version 1.9.0 and tested up to WordPress 7.0.2.
- Harden option defaults so missing or malformed settings keep a known shape.
- Preserve REST root route handling and sanitize/escape settings screen input/output.
- Fix the settings screen so selecting Manage REST API Access immediately reveals route options, and namespace toggles update child routes correctly.

## Why
WordPress 7.0.2 is the current maintained WordPress release, and the plugin's published metadata still said tested up to 6.3 with a stable tag of 1.8. While testing, the REST root route also needed explicit preservation so it is blocked consistently like concrete REST endpoints.

The settings UI also had a JavaScript bug: the display helper attached click listeners instead of changing the element's display, so switching a role from Allow Full REST API Access to Manage REST API Access could leave the route options hidden until the state changed in another way. Namespace parent toggles also used getElementById() with selector strings, so child route toggles were not updated correctly.

## Validation
- PHP linted all plugin PHP files with php -l.
- JS syntax checked admin-header.js and admin-footer.js with node --check.
- Deployed the fork to the test site on WordPress 7.0.2.
- Activated the plugin successfully on the test site.
- Verified the test site registers 129 REST routes for the settings page.
- Verified settings visibility toggle behavior with a DOM mock: Allow Full hides routes; Manage shows routes.
- Verified namespace toggle behavior with a DOM mock: parent toggles update matching child routes.
- Anonymous ?rest_route=/ returns 401 rest_cannot_access.
- Anonymous ?rest_route=/wp/v2/posts returns 401 rest_cannot_access.
- Authenticated ?rest_route=/wp/v2/posts returns 200 JSON.
- Homepage returns 200 HTML.
